### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/fylla/completion_generator.rb
+++ b/lib/fylla/completion_generator.rb
@@ -154,7 +154,7 @@ module Fylla
         # @param template [String] an ERB template
         # @param bind [Binding] a binding to a context
         def create_completion_string(template, bind)
-          template = ERB.new(template, nil, '-<>')
+          template = ERB.new(template, trim_mode:'-<>')
           template.result(bind)
         end
 


### PR DESCRIPTION
Fixes warnings:
Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead