### PR TITLE
fixed thor link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Fylla
 
-Fylla, the Norse word for `complete`, is an autocompletion script generator for the [Thor](whatisthor.com) framework.
+Fylla, the Norse word for `complete`, is an autocompletion script generator for the [Thor](http://whatisthor.com) framework.
 
 It currently generates zsh completion scripts, but will soon have support for bash scripts as well. 
 


### PR DESCRIPTION
The current link to the Thor page is parsed by GitHub as a local file, so it tries to navigate to https://github.com/snowe2010/fylla/blob/master/whatisthor.com instead of http://whatisthor.com/.

This change simply adds `http://` to the URL to have GitHub properly parse it as an external URL.