### PR TITLE
fixed CODE_OF_CONDUCT link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Fylla project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/fylla/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Fylla project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](CODE_OF_CONDUCT.md).
 
 ## Todo list
 


### PR DESCRIPTION
The current [code of conduct link](https://github.com/%5BUSERNAME%5D/fylla/blob/master/CODE_OF_CONDUCT.md) in the README redirects to a broken link due to the `[USERNAME]` parameter which I'm assuming was autogenerated initially.

This PR changes it to a format that GitHub correctly parses as a [local file link](https://github.com/snowe2010/fylla/blob/master/CODE_OF_CONDUCT.md).